### PR TITLE
Compatible with Meteor 3.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     summary: 'Layout Manager for Blaze (works well with FlowRouter)',
-    version: '2.3.1',
+    version: '2.3.2',
     git: 'https://github.com/trychlos/pwix-blaze-layout',
     name: "pwix:blaze-layout"
 });
@@ -22,8 +22,8 @@ Package.onTest( function( api ){
 });
 
 function configure( api ){
-    api.versionsFrom( '1.0' );
-    api.use( 'blaze' );
+    api.versionsFrom( ['1.0', '3.0-beta.0'] );
+    api.use( 'blaze@2.0.3 || 3.0.0-alpha300.17' );
     api.use( 'templating' );
     api.use( 'reactive-dict' );
     api.use( 'underscore' );

--- a/tests/client/integration.js
+++ b/tests/client/integration.js
@@ -1,7 +1,7 @@
 Tinytest.addAsync("Integration - render to the dom", function(test, done) {
   BlazeLayout.reset();
   BlazeLayout.render('layout1', {aa: 200});
-  Tracker.afterFlush(function() {
+  Template.layout1.onRendered(function() {
     test.isTrue(/200/.test($('#__blaze-root').text()));
     Meteor.setTimeout(done, 0);
   });


### PR DESCRIPTION
- Fixed test that was failing due to layout not being rendered before assertion.
- Updated dependencies and `api.versionsFrom` for Meteor 3.0 compatibility.